### PR TITLE
Convert json parser to use Newtonsoft.Json.

### DIFF
--- a/ApiClientLib/ApiClientLib.csproj
+++ b/ApiClientLib/ApiClientLib.csproj
@@ -30,8 +30,8 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Jayrock.Json">
-      <HintPath>..\packages\jayrock-json.0.9.16530\lib\net40\Jayrock.Json.dll</HintPath>
+    <Reference Include="Newtonsoft.Json, Version=11.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\packages\Newtonsoft.Json.11.0.2\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/ApiClientLib/Client.cs
+++ b/ApiClientLib/Client.cs
@@ -84,7 +84,7 @@ namespace ApiClientLib
                 headers = new Dictionary<string, string>();
             }
 
-            AddDirectoryAndBasename(remotePath, headers);           
+            AddDirectoryAndBasename(remotePath, headers);
             var dataStream = new MemoryStream();
 
             var respHeaders = this.httpRetry.Invoke(this.urls.MpCreate, dataStream, remotePath, headers);

--- a/ApiClientLib/Client.cs
+++ b/ApiClientLib/Client.cs
@@ -1,8 +1,8 @@
-﻿using Jayrock.Json;
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Net;
+using Newtonsoft.Json.Linq;
 
 namespace ApiClientLib
 {
@@ -57,8 +57,8 @@ namespace ApiClientLib
                 var codeGetter = new DictCodeGetter();
                 var result = this.rpcRetry.Invoke("completeMultipart", argMaker, codeGetter);
 
-                var dict = (JsonObject)result;
-                return ((JsonNumber)dict["numpieces"]).ToInt32();
+                var dict = (JObject)result;
+                return dict.GetValue("numpieces").ToObject<int>();
             }
             catch (ApiException)
             {

--- a/ApiClientLib/Client.cs
+++ b/ApiClientLib/Client.cs
@@ -254,7 +254,7 @@ namespace ApiClientLib
         {
             this.InvokeCodeBasedMethod("deleteDir", remotePath);
         }
-        
+
         /// <summary>
         /// deletes a file
         /// 
@@ -325,14 +325,14 @@ namespace ApiClientLib
         /// lists directories with in remotePath
         /// </summary>
         /// <param name="remotePath">full path in which to list directories</param>
-        /// <param name="pageOffset">offset from which to start listing items</param>
         /// <param name="pageSize">number of items per page</param>
+        /// <param name="cookie">cookie</param>
         /// <param name="includeStat">include stat data </param>
-        public ListDirResults ListDir(string remotePath, int pageSize, int pageOffset, bool includeStat)
+        public ListDirResults ListDir(string remotePath, int pageSize, ulong cookie, bool includeStat)
         {
             try
             {
-                var argMaker = new AutoTokenArgMaker(remotePath, pageSize, pageOffset, includeStat);
+                var argMaker = new AutoTokenArgMaker(remotePath, pageSize, cookie, includeStat);
                 var codeGetter = new DictCodeGetter();
                 var result = this.rpcRetry.Invoke("listDir", argMaker, codeGetter);
 
@@ -346,8 +346,8 @@ namespace ApiClientLib
             }
             catch (Exception ex)
             {
-                throw new UnknownApiException(string.Format("listDir failed with remotePath={0}, pageOffset={1}, pageSize={2}",
-                    remotePath, pageOffset, pageSize), ex);
+                throw new UnknownApiException(string.Format("listDir failed with remotePath={0}, pageSize={1}",
+                    remotePath, pageSize), ex);
             }
         }
 
@@ -355,14 +355,14 @@ namespace ApiClientLib
         /// lists files with in remotePath
         /// </summary>
         /// <param name="remotePath">full path in which to list files</param>
-        /// <param name="pageOffset">offset from which to start listing items</param>
         /// <param name="pageSize">number of items per page</param>
+        /// <param name="cookie">cookie</param>
         /// <param name="includeStat">include stat data </param>
-        public ListFileResults ListFile(string remotePath, int pageSize, int pageOffset, bool includeStat)
+        public ListFileResults ListFile(string remotePath, int pageSize, ulong cookie, bool includeStat)
         {
             try
             {
-                var argMaker = new AutoTokenArgMaker(remotePath, pageSize, pageOffset, includeStat);
+                var argMaker = new AutoTokenArgMaker(remotePath, pageSize, cookie, includeStat);
                 var codeGetter = new DictCodeGetter();
                 var result = this.rpcRetry.Invoke("listFile", argMaker, codeGetter);
                 
@@ -376,8 +376,8 @@ namespace ApiClientLib
             }
             catch (Exception ex)
             {
-                throw new UnknownApiException(string.Format("listFile failed with remotePath={0}, pageOffset={1}, pageSize={2}",
-                    remotePath, pageOffset, pageSize), ex);
+                throw new UnknownApiException(string.Format("listFile failed with remotePath={0}, pageSize={1}",
+                    remotePath, pageSize), ex);
 
             }
         }

--- a/ApiClientLib/Login.cs
+++ b/ApiClientLib/Login.cs
@@ -1,5 +1,5 @@
-﻿using Jayrock.Json;
-using System;
+﻿using System;
+using Newtonsoft.Json.Linq;
 
 namespace ApiClientLib
 {
@@ -35,7 +35,7 @@ namespace ApiClientLib
             try
             {
                 result = this.transport.Invoke("login", this.user, this.password, true);
-                this.LoginResult = new LoginResult().FromJsonObject((JsonArray)result);
+                this.LoginResult = new LoginResult().FromJsonObject((JArray)result);
                 return this.LoginResult;
             }
             catch (Exception ex)

--- a/ApiClientLib/Retry.cs
+++ b/ApiClientLib/Retry.cs
@@ -58,7 +58,7 @@ namespace ApiClientLib
 
     public interface IHttpRetry
     {
-        WebHeaderCollection Invoke(string apiUrl, Stream dataStream, string tag, Dictionary<string, string> headers);
+        WebHeaderCollection Invoke(Uri apiUrl, Stream dataStream, string tag, Dictionary<string, string> headers);
     }
 
     public class HttpRetry : IHttpRetry
@@ -75,7 +75,7 @@ namespace ApiClientLib
             this.maxTries = tries;
         }
 
-        public WebHeaderCollection Invoke(string apiUrl, Stream dataStream, string tag, Dictionary<string,string> headers) 
+        public WebHeaderCollection Invoke(Uri apiUrl, Stream dataStream, string tag, Dictionary<string,string> headers) 
         {
             int lastHttpStatus = HttpCode.Forbidden;
             int lastAgileStatus = -1;

--- a/ApiClientLib/Retry.cs
+++ b/ApiClientLib/Retry.cs
@@ -1,9 +1,8 @@
-﻿
-using Jayrock.Json;
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Net;
+using Newtonsoft.Json.Linq;
 
 namespace ApiClientLib
 {
@@ -170,7 +169,7 @@ namespace ApiClientLib
         public int GetCode(object json) {
             try
             {
-                return ((JsonNumber)json).ToInt32();
+                return ((JToken)json).ToObject<Int32>();
             }
             catch
             {
@@ -185,8 +184,8 @@ namespace ApiClientLib
         {
             try
             {
-                var oJson = (JsonObject)json;
-                return ((JsonNumber)oJson["code"]).ToInt32();
+                var oJson = (JObject)json;
+                return oJson["code"].ToObject<Int32>();
             }
             catch
             {

--- a/ApiClientLib/Transport.cs
+++ b/ApiClientLib/Transport.cs
@@ -18,11 +18,11 @@ namespace ApiClientLib
     public class JsonTransport :IJsonTransport
     {
         private int lastId;
-        private string url;
+        private Uri url;
         private int timeout;
 
-        public JsonTransport(string url) : this(url, 30000) {}
-        public JsonTransport(string url, int timeout)
+        public JsonTransport(Uri url) : this(url, 30000) {}
+        public JsonTransport(Uri url, int timeout)
         {
             this.url = url;
             this.lastId = 1;
@@ -70,7 +70,7 @@ namespace ApiClientLib
 
     public interface IHttpTransport
     {
-        WebHeaderCollection Post(string apiUrl, string token, Stream dataStream, string tag, Dictionary<string, string> headers);
+        WebHeaderCollection Post(Uri apiUrl, string token, Stream dataStream, string tag, Dictionary<string, string> headers);
     }
 
     public class HttpTransport : IHttpTransport
@@ -82,7 +82,7 @@ namespace ApiClientLib
             this.timeout = timeout;
         }
 
-        public WebHeaderCollection Post(string apiUrl, string token, Stream dataStream, string tag, Dictionary<string, string> headers)
+        public WebHeaderCollection Post(Uri apiUrl, string token, Stream dataStream, string tag, Dictionary<string, string> headers)
         {
             var request = HttpWebRequest.Create(apiUrl);
             request.Timeout = this.timeout;

--- a/ApiClientLib/Transport.cs
+++ b/ApiClientLib/Transport.cs
@@ -1,9 +1,10 @@
-﻿using Jayrock.Json;
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Net;
 using System.Text;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
 
 namespace ApiClientLib
 {
@@ -38,11 +39,12 @@ namespace ApiClientLib
             {
                 using (var writer = new StreamWriter(stream))
                 {
-                    var call = new JsonObject();
-                    call["id"] = ++this.lastId;
-                    call["method"] = method;
-                    call["params"] = args;
-                    call.Export(new JsonTextWriter(writer));
+                    JObject call = new JObject(
+                        new JProperty("id", ++this.lastId),
+                        new JProperty("method", method),
+                        new JProperty("params", args)
+                    );
+                    writer.Write(call.ToString());
                 }
             }
 
@@ -52,11 +54,9 @@ namespace ApiClientLib
                 {
                     using (var reader = new StreamReader(stream, Encoding.UTF8))
                     {
-                        var answer = new JsonObject();
-                        answer.Import(new JsonTextReader(reader));
-
+                        JObject answer = JObject.Parse(reader.ReadToEnd());
                         var errorObject = answer["error"];
-                        if (errorObject != null)
+                        if (errorObject.Type != JTokenType.Null)
                         {
                             throw new JsonException(errorObject.ToString());
                         }

--- a/ApiClientLib/Types.cs
+++ b/ApiClientLib/Types.cs
@@ -14,10 +14,6 @@ namespace ApiClientLib
 
         public LoginResult FromJsonObject(JArray json)
         {
-            if (json.Count == 2 && json[0] == null && json[1] == null)
-            {
-                throw new LoginException(json.ToString());
-            }
             this.Token = (string)json[0];
             var userInfo = json[1].ToObject<JObject>();
             this.Gid = userInfo["gid"].ToObject<Int32>();
@@ -86,12 +82,12 @@ namespace ApiClientLib
 
     public class ListDirResults : List<ListDirResult>
     {
-        public int Cookie;
+        public ulong Cookie;
 
         public ListDirResults FromJsonObject(object obj)
         {
             var json = (JObject)obj;
-            this.Cookie = json["cookie"].ToObject<Int32>();
+            this.Cookie = json["cookie"].ToObject<UInt64>();
             var list = (JArray)json["list"];
             this.Clear();
 
@@ -129,12 +125,12 @@ namespace ApiClientLib
 
     public class ListFileResults : List<ListFileResult>
     {
-        public int Cookie;
+        public ulong Cookie;
 
         public ListFileResults FromJsonObject(object obj)
         {
             var json = (JObject)obj;
-            this.Cookie = json["cookie"].ToObject<Int32>();
+            this.Cookie = json["cookie"].ToObject<UInt64>();
             var list = (JArray)json["list"];
             this.Clear();
 

--- a/ApiClientLib/Types.cs
+++ b/ApiClientLib/Types.cs
@@ -1,7 +1,7 @@
-﻿using Jayrock.Json;
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Net;
+using Newtonsoft.Json.Linq;
 
 namespace ApiClientLib
 {
@@ -12,16 +12,16 @@ namespace ApiClientLib
         public int Uid;
         public string Path;
 
-        public LoginResult FromJsonObject(JsonArray json)
+        public LoginResult FromJsonObject(JArray json)
         {
-            if (json.Length == 2 && json[0] == null && json[1] == null)
+            if (json.Count == 2 && json[0] == null && json[1] == null)
             {
                 throw new LoginException(json.ToString());
             }
             this.Token = (string)json[0];
-            var userInfo = (JsonObject)json[1];
-            this.Gid = ((JsonNumber)userInfo["gid"]).ToInt32();
-            this.Uid = ((JsonNumber)userInfo["uid"]).ToInt32();
+            var userInfo = json[1].ToObject<JObject>();
+            this.Gid = userInfo["gid"].ToObject<Int32>();
+            this.Uid = userInfo["uid"].ToObject<Int32>();
             this.Path = (string)userInfo["path"];
             return this;
         }
@@ -68,18 +68,18 @@ namespace ApiClientLib
 
         public StatResult FromJsonObject(object obj)
         {
-            var json = (JsonObject)obj;
-            this.Code = ((JsonNumber)json["code"]).ToInt32();
-            this.Ctime = ((JsonNumber)json["ctime"]).ToInt32();
+            var json = (JObject)obj;
+            this.Code = json["code"].ToObject<Int32>();
+            this.Ctime = json["ctime"].ToObject<Int32>();
             this.Checksum = (string)json["checksum"];
-            this.Gid = ((JsonNumber)json["gid"]).ToInt32();
-            this.Mtime = ((JsonNumber)json["mtime"]).ToInt32();           
-            this.Type = ((JsonNumber)json["type"]).ToInt32();
+            this.Gid = json["gid"].ToObject<Int32>();
+            this.Mtime = json["mtime"].ToObject<Int32>();
+            this.Type = json["type"].ToObject<Int32>();
             if (this.Type == 2)
             {
-                this.Size = ((JsonNumber)json["size"]).ToInt64();
+                this.Size = json["size"].ToObject<Int64>();
             }
-            this.Uid = ((JsonNumber)json["uid"]).ToInt32();
+            this.Uid = json["uid"].ToObject<Int32>();
             return this;
         }
     }
@@ -90,12 +90,12 @@ namespace ApiClientLib
 
         public ListDirResults FromJsonObject(object obj)
         {
-            var json = (JsonObject)obj;
-            this.Cookie = ((JsonNumber)json["cookie"]).ToInt32();
-            var list = (JsonArray)json["list"];
+            var json = (JObject)obj;
+            this.Cookie = json["cookie"].ToObject<Int32>();
+            var list = (JArray)json["list"];
             this.Clear();
 
-            foreach (JsonObject item in list)
+            foreach (JObject item in list)
             {
                 this.Add(new ListDirResult().FromJsonObject(item));
             }
@@ -107,19 +107,21 @@ namespace ApiClientLib
     {
         public string Name;
 
-        public ListDirResult FromJsonObject(JsonObject json)
+        public ListDirResult FromJsonObject(JObject json)
         {
-            var stat = (JsonObject)json["stat"];
+            var stat = (JObject)json["stat"];
             this.Name = (string)json["name"];
-
-            var oType = json.Contains("type") ? ((JsonNumber)json["type"]).ToInt32() : 2;
+            JToken typeToken = null;
+            var oType = 2;
+            if (json.TryGetValue("type", out typeToken))
+                oType = json["type"].ToObject<Int32>();
             
-            if (stat != null)
+            if (stat.Type != JTokenType.Null)
             {
-                this.Ctime = ((JsonNumber)stat["ctime"]).ToInt32();
-                this.Gid = ((JsonNumber)stat["gid"]).ToInt32();
-                this.Mtime = ((JsonNumber)stat["mtime"]).ToInt32();
-                this.Uid = ((JsonNumber)stat["uid"]).ToInt32();
+                this.Ctime = stat["ctime"].ToObject<Int32>();
+                this.Gid = stat["gid"].ToObject<Int32>();
+                this.Mtime = stat["mtime"].ToObject<Int32>();
+                this.Uid = stat["uid"].ToObject<Int32>();
             }
             return this;
         }
@@ -131,12 +133,12 @@ namespace ApiClientLib
 
         public ListFileResults FromJsonObject(object obj)
         {
-            var json = (JsonObject)obj;
-            this.Cookie = ((JsonNumber)json["cookie"]).ToInt32();
-            var list = (JsonArray)json["list"];
+            var json = (JObject)obj;
+            this.Cookie = json["cookie"].ToObject<Int32>();
+            var list = (JArray)json["list"];
             this.Clear();
 
-            foreach (JsonObject item in list)
+            foreach (JObject item in list)
             {
                 this.Add(new ListFileResult().FromJsonObject(item));
             }
@@ -148,21 +150,21 @@ namespace ApiClientLib
     {
         public string ContentType;
 
-        public ListFileResult FromJsonObject(JsonObject json)
+        public ListFileResult FromJsonObject(JObject json)
         {
-            var stat = (JsonObject)json["stat"];
+            var stat = (JObject)json["stat"];
             this.Name = (string)json["name"];
-            this.Type = ((JsonNumber)json["type"]).ToInt32();
+            this.Type = json["type"].ToObject<Int32>();
 
-            if (stat != null)
+            if (stat.Type != JTokenType.Null)
             {
                 this.Checksum = (string)stat["checksum"];
-                this.Ctime = ((JsonNumber)stat["ctime"]).ToInt32();
-                this.Gid = ((JsonNumber)stat["gid"]).ToInt32();
+                this.Ctime = stat["ctime"].ToObject<Int32>();
+                this.Gid = stat["gid"].ToObject<Int32>();
                 this.ContentType = (string)stat["mimetype"];
-                this.Mtime = ((JsonNumber)stat["mtime"]).ToInt32();
-                this.Size = ((JsonNumber)stat["size"]).ToInt64();
-                this.Uid = ((JsonNumber)stat["uid"]).ToInt32();
+                this.Mtime = stat["mtime"].ToObject<Int32>();
+                this.Size = stat["size"].ToObject<Int64>();
+                this.Uid = stat["uid"].ToObject<Int32>();
             }
             return this;
         }
@@ -176,21 +178,21 @@ namespace ApiClientLib
 
         public ListPathResults FromJsonObject(object obj)
         {
-            var json = (JsonObject)obj;
+            var json = (JObject)obj;
             this.Cookie = (string)json["cookie"];
          
-            var dirs = (JsonArray)json["dirs"];
+            var dirs = (JArray)json["dirs"];
             
-            foreach (JsonObject dir in dirs)
+            foreach (JObject dir in dirs)
             {
                 var dirResult = new ListDirResult();
                 dirResult.FromJsonObject(dir);
                 this.Dirs.Add(dirResult);
             }
 
-            var files = (JsonArray)json["files"];
+            var files = (JArray)json["files"];
 
-            foreach (JsonObject file in files)
+            foreach (JObject file in files)
             {
                 this.Files.Add(new ListPathFileResult().FromJsonObject(file));
             }
@@ -202,20 +204,20 @@ namespace ApiClientLib
     {
         public int ContentType;
 
-        public ListPathFileResult FromJsonObject(JsonObject json)
+        public ListPathFileResult FromJsonObject(JObject json)
         {
-            var stat = (JsonObject)json["stat"];
+            var stat = (JObject)json["stat"];
             this.Name = (string)json["name"];
            
-            if (stat != null)
+            if (stat.Type != JTokenType.Null)
             {
                 this.Checksum = (string)stat["hash"];
-                this.Ctime = ((JsonNumber)stat["ctime"]).ToInt32();
-                this.ContentType = ((JsonNumber)stat["ctype"]).ToInt32();                
-                this.Gid = ((JsonNumber)stat["gid"]).ToInt32();
-                this.Mtime = ((JsonNumber)stat["mtime"]).ToInt32();
-                this.Size = ((JsonNumber)stat["size"]).ToInt64();
-                this.Uid = ((JsonNumber)stat["uid"]).ToInt32();
+                this.Ctime = stat["ctime"].ToObject<Int32>();
+                this.ContentType = stat["ctype"].ToObject<Int32>();
+                this.Gid = stat["gid"].ToObject<Int32>();
+                this.Mtime = stat["mtime"].ToObject<Int32>();
+                this.Size = stat["size"].ToObject<Int64>();
+                this.Uid = stat["uid"].ToObject<Int32>();
             }
             return this;
         }
@@ -234,13 +236,13 @@ namespace ApiClientLib
 
         public MultipartInfo FromJsonObject(object obj)
         {
-            var json = (JsonObject)obj;
-            this.Created = ((JsonNumber)json["created"]).ToInt32();
-            this.Mtime = ((JsonNumber)json["mtime"]).ToInt32();
-            this.NumPieces = ((JsonNumber)json["numpieces"]).ToInt32();
-            this.State = ((JsonNumber)json["state"]).ToInt32();
+            var json = (JObject)obj;
+            this.Created = json["created"].ToObject<Int32>();
+            this.Mtime = json["mtime"].ToObject<Int32>();
+            this.NumPieces = json["numpieces"].ToObject<Int32>();
+            this.State = json["state"].ToObject<Int32>();
             this.ContentType = (string)json["content_type"];
-            this.Error = ((JsonNumber)json["error"]).ToInt32();
+            this.Error = json["error"].ToObject<Int32>();
             this.Path = (string)json["path"];
             return this;
         }
@@ -252,12 +254,12 @@ namespace ApiClientLib
 
         public MultipartResults FromJsonObject(object obj)
         {
-            var json = (JsonObject)obj;
-            this.Cookie = ((JsonNumber)json["cookie"]).ToInt32();
+            var json = (JObject)obj;
+            this.Cookie = json["cookie"].ToObject<Int32>();
 
-            var list = (JsonArray)json["multipart"];
+            var list = (JArray)json["multipart"];
 
-            foreach (JsonObject item in list)
+            foreach (JObject item in list)
             {
                 var mpResult = new MultipartResult();
                 mpResult.FromJsonObject(item);
@@ -275,18 +277,18 @@ namespace ApiClientLib
         public string MpId;
         public int Mtime;
         public string Path;
-        public int State;        
+        public int State;
         public int Uid;
 
-        public MultipartResult FromJsonObject(JsonObject json)
+        public MultipartResult FromJsonObject(JObject json)
         {        
-            this.Error = ((JsonNumber)json["error"]).ToInt32();
-            this.Gid = ((JsonNumber)json["gid"]).ToInt32();
+            this.Error = json["error"].ToObject<Int32>();
+            this.Gid = json["gid"].ToObject<Int32>();
             this.MpId = (string)json["mpid"];
-            this.Mtime = ((JsonNumber)json["mtime"]).ToInt32();
-            this.Path = (string)json["path"];            
-            this.State = ((JsonNumber)json["state"]).ToInt32();
-            this.Uid = ((JsonNumber)json["uid"]).ToInt32();                    
+            this.Mtime = json["mtime"].ToObject<Int32>();
+            this.Path = (string)json["path"];
+            this.State = json["state"].ToObject<Int32>();
+            this.Uid = json["uid"].ToObject<Int32>();
             return this;
         }
     }
@@ -297,12 +299,12 @@ namespace ApiClientLib
 
         public MultipartPieceResults FromJsonObject(object obj)
         {
-            var json = (JsonObject)obj;
-            this.Cookie = ((JsonNumber)json["cookie"]).ToInt32();
+            var json = (JObject)obj;
+            this.Cookie = json["cookie"].ToObject<Int32>();
 
-            var list = (JsonArray)json["pieces"];
+            var list = (JArray)json["pieces"];
 
-            foreach (JsonObject item in list)
+            foreach (JObject item in list)
             {
                 var mpResult = new MultipartPieceResult();
                 mpResult.FromJsonObject(item);
@@ -319,11 +321,11 @@ namespace ApiClientLib
         public int Number;
         public int State;
 
-        public MultipartPieceResult FromJsonObject(JsonObject json)
+        public MultipartPieceResult FromJsonObject(JObject json)
         {
-            this.Error = ((JsonNumber)json["error"]).ToInt32();
-            this.Number = ((JsonNumber)json["number"]).ToInt32();
-            this.State = ((JsonNumber)json["state"]).ToInt32();
+            this.Error = json["error"].ToObject<Int32>();
+            this.Number = json["number"].ToObject<Int32>();
+            this.State = json["state"].ToObject<Int32>();
             return this;
         }
     }
@@ -383,6 +385,10 @@ namespace ApiClientLib
         public static int Success = 0;
         public static int DirNotFound = -1;
         public static int FileNotFound = -1;
+        public static int PathExists = -2;
+        public static int NoParentDir = -3;
+        public static int ServiceUnavailable = -5;
+        public static int InvalidPath = -8;
         public static int UnknownError = -999;
         public static int ExpiredToken = -10001;
     }

--- a/ApiClientLib/Types.cs
+++ b/ApiClientLib/Types.cs
@@ -115,8 +115,8 @@ namespace ApiClientLib
             var oType = 2;
             if (json.TryGetValue("type", out typeToken))
                 oType = json["type"].ToObject<Int32>();
-            
-            if (stat.Type != JTokenType.Null)
+
+            if ((stat != null) && (stat.Type != JTokenType.Null))
             {
                 this.Ctime = stat["ctime"].ToObject<Int32>();
                 this.Gid = stat["gid"].ToObject<Int32>();
@@ -156,7 +156,7 @@ namespace ApiClientLib
             this.Name = (string)json["name"];
             this.Type = json["type"].ToObject<Int32>();
 
-            if (stat.Type != JTokenType.Null)
+            if ((stat != null) && (stat.Type != JTokenType.Null))
             {
                 this.Checksum = (string)stat["checksum"];
                 this.Ctime = stat["ctime"].ToObject<Int32>();
@@ -208,8 +208,8 @@ namespace ApiClientLib
         {
             var stat = (JObject)json["stat"];
             this.Name = (string)json["name"];
-           
-            if (stat.Type != JTokenType.Null)
+
+            if ((stat != null) && (stat.Type != JTokenType.Null))
             {
                 this.Checksum = (string)stat["hash"];
                 this.Ctime = stat["ctime"].ToObject<Int32>();
@@ -362,21 +362,23 @@ namespace ApiClientLib
 
     public class Urls
     {
-        public string PostRaw;
-        public string PostForm;
-        public string RpcUrl;
-        public string MpPiece;
-        public string MpCreate;
-        public string MpComplete;
+        public Uri PostRaw;
+        public Uri PostForm;
+        public Uri RpcUrl;
+        public Uri MpPiece;
+        public Uri MpCreate;
+        public Uri MpComplete;
 
         public Urls(string apiUrl)
         {
-            this.PostRaw = apiUrl + "/post/raw";
-            this.PostForm = apiUrl + "/post/file";
-            this.RpcUrl = apiUrl + "/jsonrpc";
-            this.MpPiece = apiUrl + "/multipart/piece";
-            this.MpCreate = apiUrl + "/multipart/create";
-            this.MpComplete = apiUrl + "/multipart/complete";
+            Uri baseApiUrl = new Uri(apiUrl);
+
+            this.PostRaw = new Uri(baseApiUrl, "/post/raw");
+            this.PostForm = new Uri(baseApiUrl, "/post/file");
+            this.RpcUrl = new Uri(baseApiUrl, "/jsonrpc");
+            this.MpPiece = new Uri(baseApiUrl, "/multipart/piece");
+            this.MpCreate = new Uri(baseApiUrl, "/multipart/create");
+            this.MpComplete = new Uri(baseApiUrl, "/multipart/complete");
         }
     }
 

--- a/ApiClientLib/packages.config
+++ b/ApiClientLib/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="jayrock-json" version="0.9.16530" targetFramework="net45" />
+  <package id="Newtonsoft.Json" version="11.0.2" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
This pull request is to change the JSON parser to use Netwonsoft.Json.
Newtonsoft.Json has better support for .NET Standard in Nuget where as Jayrock.Json does not.

https://www.nuget.org/packages/Newtonsoft.Json